### PR TITLE
Feature: Fetch Before

### DIFF
--- a/server/src/main/java/dev/nextchat/server/protocol/factory/FetchBeforeMessageCommandFactory.java
+++ b/server/src/main/java/dev/nextchat/server/protocol/factory/FetchBeforeMessageCommandFactory.java
@@ -1,0 +1,38 @@
+package dev.nextchat.server.protocol.factory;
+
+import dev.nextchat.server.messaging.service.MessageService;
+import dev.nextchat.server.group.service.GroupService;
+import dev.nextchat.server.protocol.Command;
+import dev.nextchat.server.protocol.CommandType;
+import dev.nextchat.server.protocol.impl.FetchBeforeMessageCommand;
+
+import org.json.JSONObject;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+import java.time.Instant;
+
+@Component
+public class FetchBeforeMessageCommandFactory implements CommandFactory {
+    
+    private final MessageService messageService;
+    private final GroupService groupService;
+
+    public FetchBeforeMessageCommandFactory(MessageService messageService, GroupService groupService) {
+        this.messageService = messageService;
+        this.groupService = groupService;
+    }
+
+    @Override
+    public Command create(JSONObject json) throws Exception {
+        UUID groupId = UUID.fromString(json.getString("groupId"));
+        Instant timestamp = Instant.parse(json.getString("timestamp"));
+        return new FetchBeforeMessageCommand(groupId, messageService, groupService, timestamp);
+    }
+
+    @Override
+    public CommandType getType() {
+        return CommandType.FETCH_BEFORE;
+    }
+}

--- a/server/src/main/java/dev/nextchat/server/protocol/factory/FetchBeforeMessageCommandFactory.java
+++ b/server/src/main/java/dev/nextchat/server/protocol/factory/FetchBeforeMessageCommandFactory.java
@@ -27,7 +27,20 @@ public class FetchBeforeMessageCommandFactory implements CommandFactory {
     @Override
     public Command create(JSONObject json) throws Exception {
         UUID groupId = UUID.fromString(json.getString("groupId"));
-        Instant timestamp = Instant.parse(json.getString("timestamp"));
+
+        String timestampStr = json.getString("timestamp");
+        
+        // Validate and parse the timestamp
+        Instant timestamp;
+        try {
+            if (!timestampStr.matches("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?Z$")) {
+                throw new IllegalArgumentException("Invalid timestamp format. Expected ISO-8601 format.");
+            }
+            timestamp = Instant.parse(timestampStr);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Failed to parse timestamp: " + e.getMessage(), e);
+        }
+
         return new FetchBeforeMessageCommand(groupId, messageService, groupService, timestamp);
     }
 

--- a/server/src/main/java/dev/nextchat/server/protocol/impl/FetchBeforeMessageCommand.java
+++ b/server/src/main/java/dev/nextchat/server/protocol/impl/FetchBeforeMessageCommand.java
@@ -1,0 +1,71 @@
+package dev.nextchat.server.protocol.impl;
+
+import dev.nextchat.server.messaging.model.Message;
+import dev.nextchat.server.messaging.service.MessageService;
+import dev.nextchat.server.protocol.Command;
+import dev.nextchat.server.protocol.CommandContext;
+import dev.nextchat.server.protocol.CommandType;
+import dev.nextchat.server.group.service.GroupService;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.util.List;
+import java.util.UUID; 
+
+import java.time.Instant;
+
+public class FetchBeforeMessageCommand implements Command {
+    private final UUID groupId;
+    private final MessageService messageService;
+    private final GroupService groupService;
+    private final Instant timestamp;
+
+    public FetchBeforeMessageCommand(UUID groupId, MessageService messageService, GroupService groupService, Instant timestamp) {
+        this.groupId = groupId;
+        this.messageService = messageService;
+        this.groupService = groupService;
+        this.timestamp = timestamp;
+    }
+
+    @Override
+    public CommandType getType() {
+        return CommandType.FETCH_BEFORE;
+    }
+
+    @Override
+    public JSONObject execute(CommandContext context) {
+        JSONObject response = new JSONObject();
+        response.put("type", "fetch_message_response");
+
+        if (!context.isAuthenticated()) {
+            response.put("status", "error");
+            response.put("message", "Authentication required");
+            return response;
+        }
+
+        UUID userId = context.sessionUserId();
+
+        if (!groupService.isUserInGroup(groupId, userId)) {
+            response.put("status", "error");
+            response.put("message", "User is not a member of the group");
+            return response;
+        }
+
+        List<Message> messages = messageService.findMessagesBefore(groupId, timestamp);
+
+        JSONArray jsonMessages = new JSONArray();
+        for (Message m : messages) {
+            JSONObject msg = new JSONObject();
+            msg.put("id", m.getId().toString());
+            msg.put("senderId", m.getSenderId().toString());
+            msg.put("content", m.getContent());
+            msg.put("timestamp", m.getTimestamp().toString());
+            jsonMessages.put(msg);
+        }
+
+        response.put("status", "ok");
+        response.put("messages", jsonMessages);
+        return response;
+    }
+}


### PR DESCRIPTION
New command FETCH_BEFORE: allow the user to fetch the message before a timestamp

TODO: 
- [x] Implement Command and Command Factory. 
- [x] Build and run the server on port. 
- [x] Define the timestamp format in JSON 
- [x] Test and check with real simulated messages between two clients. 
- [ ] Test with an extremely long chat with more than 20 messages and 2 clients. 